### PR TITLE
ISO C90 Compilation error

### DIFF
--- a/lib/png.rb
+++ b/lib/png.rb
@@ -16,6 +16,10 @@ class String # :nodoc: # ZenTest SKIP
       unsigned long png_crc() {
         static unsigned long crc[256];
         static char crc_table_computed = 0;
+        unsigned long c = 0xffffffff;
+        unsigned len    = RSTRING_LEN(self);
+        char * s        = StringValuePtr(self);
+        unsigned i;
 
         if (! crc_table_computed) {
           unsigned long c;
@@ -31,11 +35,6 @@ class String # :nodoc: # ZenTest SKIP
           crc_table_computed = 1;
         }
 
-        unsigned long c = 0xffffffff;
-        unsigned len    = RSTRING_LEN(self);
-        char * s        = StringValuePtr(self);
-        unsigned i;
-
         for (i = 0; i < len; i++) {
           c = crc[(c ^ s[i]) & 0xff] ^ (c >> 8);
         }
@@ -45,7 +44,7 @@ class String # :nodoc: # ZenTest SKIP
     EOM
   end
 rescue CompilationError => e
-  warn "COMPLIATION ERROR: #{e}"
+  warn "COMPILATION ERROR: #{e}"
 
   unless defined? @@crc then
     @@crc = Array.new(256)


### PR DESCRIPTION
I haven't yet fully grokked why this error was occurring, or why I was getting it on my CI Server (TeamCity with Ubuntu agents) and not my dev machine (MBP). But a trivial patch fixed the error and got my CI box working again, so thought I would share it back up.  My error message was:

```
[18:46:27]: [Execute parallel:drop] /home/bkr/.bundle/ruby/1.9.1/gems/png-1.2.0/lib/png.rb: In function ‘png_crc’:
[18:46:27]: [Execute parallel:drop] /home/bkr/.bundle/ruby/1.9.1/gems/png-1.2.0/lib/png.rb:35: error: ISO C90 forbids mixed declarations and code
[18:46:27]: [Execute parallel:drop] COMPLIATION ERROR: error executing "gcc -shared   -fPIC  -O3 -ggdb -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Werror=pointer-arith -Werror=write-strings -Werror=declaration-after-statement -Werror=implicit-function-declaration  -fPIC -L.  -rdynamic -Wl,-export-dynamic -I /usr/local/rvm/rubies/ruby-1.9.3-p0/include/ruby-1.9.1 -I /usr/local/rvm/rubies/ruby-1.9.3-p0/include/ruby-1.9.1/x86_64-linux -I /usr/local/rvm/rubies/ruby-1.9.3-p0/include -L/usr/local/rvm/rubies/ruby-1.9.3-p0/lib -o \"/home/bkr/.ruby_inline/ruby-1.9.1/Inline_String_9a6686966a50705d94442f198bc2c408.so\" \"/home/bkr/.ruby_inline/ruby-1.9.1/Inline_String_9a6686966a50705d94442f198bc2c408.c\"  ": pid 22443 exit 1
[18:46:27]: [Execute parallel:drop] Renamed /home/bkr/.ruby_inline/ruby-1.9.1/Inline_String_9a6686966a50705d94442f198bc2c408.c to /home/bkr/.ruby_inline/ruby-1.9.1/Inline_String_9a6686966a50705d94442f198bc2c408.c.bad
```

This, using png 1.2.0 and RubyInline 3.11.1. This didn't happen when installing the gems (the rescue was catching it and throwing up the warning, as expected), but when rake started setting up my test databases. The actual error was:

```
[18:21:34]: [Execute parallel:create] No such file or directory - (/home/bkr/.ruby_inline/ruby-1.9.1/Inline_String_9a6686966a50705d94442f198bc2c408.c, /home/bkr/.ruby_inline/ruby-1.9.1/Inline_String_9a6686966a50705d94442f198bc2c408.c.bad)
[18:21:34]: [Execute parallel:create] /home/bkr/tc/work/356aad6c66dfbcbb/cart/Rakefile:1:in `require'
```
